### PR TITLE
feat(navigation/bar): fix navigation item when display name is short

### DIFF
--- a/app/components/navigation/bar.tsx
+++ b/app/components/navigation/bar.tsx
@@ -70,7 +70,7 @@ export function NavigationBar({ profile }: NavigationBarProps) {
           {profile ? (
             <>
               <NavigationMenuItem>
-                <NavigationMenuTrigger className="flex gap-2 p-2">
+                <NavigationMenuTrigger className="flex gap-2 p-2 min-w-[100px]">
                   <p className="text-lg">{profile.displayName}</p>
                 </NavigationMenuTrigger>
 


### PR DESCRIPTION
closes #117 