### PR TITLE
fix(profile/sections/top-genres): wrap `children` with div and center it

### DIFF
--- a/app/profile/sections/top-genres-section.tsx
+++ b/app/profile/sections/top-genres-section.tsx
@@ -41,7 +41,7 @@ function TopGenresSection({ items, children }: TopGenresSection.Props) {
 
       {items.length === 0 && <NoDataAlert />}
 
-      {children}
+      <div className="flex justify-center">{children}</div>
     </DefaultSection>
   )
 }

--- a/tests/snapshots/top-genres-section.spec.tsx.snap
+++ b/tests/snapshots/top-genres-section.spec.tsx.snap
@@ -72,6 +72,9 @@ exports[`TopGenresSection > should match snapshot 1`] = `
               </button>
             </div>
           </div>
+          <div
+            class="flex justify-center"
+          />
         </main>
       </section>
     </div>
@@ -144,6 +147,9 @@ exports[`TopGenresSection > should match snapshot 1`] = `
             </button>
           </div>
         </div>
+        <div
+          class="flex justify-center"
+        />
       </main>
     </section>
   </div>,
@@ -253,6 +259,9 @@ exports[`TopGenresSection > should match snapshot with no data 1`] = `
               Oops... Looks like nothing's there yet.
             </div>
           </div>
+          <div
+            class="flex justify-center"
+          />
         </main>
       </section>
     </div>
@@ -305,6 +314,9 @@ exports[`TopGenresSection > should match snapshot with no data 1`] = `
             Oops... Looks like nothing's there yet.
           </div>
         </div>
+        <div
+          class="flex justify-center"
+        />
       </main>
     </section>
   </div>,


### PR DESCRIPTION
closes #406 