### PR TITLE
fix(utils/find-image): return `defaultCover` if no image found

### DIFF
--- a/app/utils/find-image.spec.ts
+++ b/app/utils/find-image.spec.ts
@@ -3,6 +3,7 @@ import { findImage } from './find-image'
 import type { Image } from '@app/api/types'
 
 describe('getImage', () => {
+  const defaultCover = 'https://dev.afrocharts.com/images/song_cover.png'
   let imagesMock: Image[]
 
   beforeEach(() => {
@@ -23,7 +24,7 @@ describe('getImage', () => {
   test('should return empty string if item is undefined', () => {
     const noImage = undefined
 
-    expect(findImage(noImage)).toEqual('')
+    expect(findImage(noImage)).toEqual(defaultCover)
   })
 
   test('should return image with width greater than or equal to minWidth', () => {
@@ -33,6 +34,10 @@ describe('getImage', () => {
 
   test('should return first image if no image with width greater than or equal to minWidth', () => {
     expect(findImage(imagesMock, 200)).toEqual(imagesMock[0].url)
+  })
+
+  test('should return default cover if images is empty', () => {
+    expect(findImage([])).toEqual(defaultCover)
   })
 
   describe('when item is track object', () => {
@@ -57,6 +62,10 @@ describe('getImage', () => {
     test('should return first image if no image with width greater than or equal to minWidth', () => {
       expect(findImage(trackMock, 300)).toEqual(imagesMock[0].url)
     })
+
+    test('should return default cover if images is empty', () => {
+      expect(findImage({ album: { images: [] } })).toEqual(defaultCover)
+    })
   })
 
   describe('when item is album or artist object', () => {
@@ -76,6 +85,10 @@ describe('getImage', () => {
 
     test('should return first image if no image with width greater than or equal to minWidth', () => {
       expect(findImage(albumOrArtistMock, 300)).toEqual(imagesMock[0].url)
+    })
+
+    test('should return default cover if images is empty', () => {
+      expect(findImage({ images: [] })).toEqual(defaultCover)
     })
   })
 })

--- a/app/utils/find-image.ts
+++ b/app/utils/find-image.ts
@@ -18,14 +18,23 @@ export type ItemWithImages =
   | []
 
 export function findImage(item?: ItemWithImages, minWidth = 0) {
-  if (!item) return ''
+  const defaultCover = 'https://dev.afrocharts.com/images/song_cover.png'
 
-  if ('images' in item)
+  if (!item) return defaultCover
+
+  if ('images' in item) {
+    if (item.images.length === 0) return defaultCover
+
     return (
       item.images.find(findImagePredicate(minWidth))?.url ?? item.images[0].url
     )
-  else if (Array.isArray(item))
+  } else if (Array.isArray(item)) {
+    if (item.length === 0) return defaultCover
+
     return item.find(findImagePredicate(minWidth))?.url ?? item[0].url
+  }
+
+  if (item.album.images.length === 0) return defaultCover
 
   return (
     item.album.images.find(findImagePredicate(minWidth))?.url ??


### PR DESCRIPTION
closes #533 