### PR TITLE
refactor(profile/reports/helpers/value-measurement-formatter): change `nothing` to `0 plays`

### DIFF
--- a/app/profile/[id]/reports/components/helpers/chart-tooltip-content-formatter.tsx
+++ b/app/profile/[id]/reports/components/helpers/chart-tooltip-content-formatter.tsx
@@ -40,7 +40,7 @@ export const chartTooltipContentFormatter = (
 
         {item.value && (
           <span className="font-mono font-medium tabular-nums text-foreground">
-            {valueMeasurementFormatter(+value, measurement, false)}
+            {valueMeasurementFormatter(+value, measurement)}
           </span>
         )}
       </div>

--- a/app/profile/[id]/reports/helpers/value-measurement-formatter.spec.ts
+++ b/app/profile/[id]/reports/helpers/value-measurement-formatter.spec.ts
@@ -15,18 +15,7 @@ describe('valueMeasurementFormatter', () => {
   })
 
   test('should return `nothing` when value is 0', () => {
-    expect(valueMeasurementFormatter(0, StatsMeasurement.PLAYS)).toBe('nothing')
-    expect(valueMeasurementFormatter(0, StatsMeasurement.PLAY_TIME)).toBe(
-      'nothing'
-    )
-  })
-
-  test('should not return `nothing` with `showZero` set to true', () => {
-    expect(valueMeasurementFormatter(0, StatsMeasurement.PLAYS, true)).toBe(
-      '0 plays'
-    )
-    expect(valueMeasurementFormatter(0, StatsMeasurement.PLAY_TIME, true)).toBe(
-      '0ms'
-    )
+    expect(valueMeasurementFormatter(0, StatsMeasurement.PLAYS)).toBe('0 plays')
+    expect(valueMeasurementFormatter(0, StatsMeasurement.PLAY_TIME)).toBe('0ms')
   })
 })

--- a/app/profile/[id]/reports/helpers/value-measurement-formatter.ts
+++ b/app/profile/[id]/reports/helpers/value-measurement-formatter.ts
@@ -2,14 +2,10 @@ import prettyMilliseconds from 'pretty-ms'
 
 import { StatsMeasurement } from '@app/api/enums'
 
-export function valueMeasurementFormatter(
+export const valueMeasurementFormatter = (
   value: number,
-  measurement: StatsMeasurement,
-  showZero = false
-) {
-  if (value === 0 && !showZero) return 'nothing'
-
-  return measurement === StatsMeasurement.PLAYS
+  measurement: StatsMeasurement
+) =>
+  measurement === StatsMeasurement.PLAYS
     ? `${value} plays`
     : prettyMilliseconds(value, { unitCount: 2 })
-}


### PR DESCRIPTION
closes #528 